### PR TITLE
Do not override the sales navigation title

### DIFF
--- a/src/Spryker/Zed/GiftCardBalance/Communication/navigation.xml
+++ b/src/Spryker/Zed/GiftCardBalance/Communication/navigation.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 <config>
     <sales>
-        <label>Gift Card Balance</label>
-        <title>Gift Card Balance</title>
-        <bundle>gift-card-balance</bundle>
         <pages>
             <gift-card>
                 <label>Gift Card Balance</label>


### PR DESCRIPTION
## 🔖  Description

This module is overriding the label and title from the Sales navigation section. This PR removes that unnecessary override.

## 🖼️  Screenshots

### BEFORE
<img width="621" alt="Screenshot 2022-01-18 at 12 30 53" src="https://user-images.githubusercontent.com/5256287/149929535-5375d526-ce49-42ce-bea8-67d22da4d3c2.png">

### AFTER
<img width="621" alt="Screenshot 2022-01-18 at 12 31 41" src="https://user-images.githubusercontent.com/5256287/149929635-8fceebb0-8bfc-4fae-ba63-0cf5bd8856cb.png">

The gift-card-balance module is still working as expected:
<img width="1158" alt="Screenshot 2022-01-18 at 12 32 59" src="https://user-images.githubusercontent.com/5256287/149929835-03595ee1-3fc5-4fa4-8fbe-95a50b2ece87.png">

